### PR TITLE
A way to set any source control plugin to inactive

### DIFF
--- a/src/NoGit/NoGitPackage.cs
+++ b/src/NoGit/NoGitPackage.cs
@@ -140,7 +140,7 @@
             if (getProvider != null)
             {
                 IVsSccProvider provider = getProvider.GetProvider();
-                if (provider != null && provider.GetType().Namespace == "Microsoft.TeamFoundation.Git.Provider")
+                if (provider != null)
                 {
                     provider.SetInactive();
                 }


### PR DESCRIPTION
I know this isn't strictly Git but I have another SCC plugin installed :cry: but this change should set any source control plugin to None I hope
